### PR TITLE
[FIX] the hostname of enpoint parser should parse dash symbol.

### DIFF
--- a/Sources/EventStoreDB/ClientSettings/Parser/EndpointParser.swift
+++ b/Sources/EventStoreDB/ClientSettings/Parser/EndpointParser.swift
@@ -87,7 +87,7 @@ class EndpointParser: ConnctionStringParser {
                 One(.word.subtracting(.anyOf(":?=&")))
             }
             Optionally {
-                One(".")
+                One(.anyOf(".-_"))
             }
         }
         Anchor.wordBoundary

--- a/Tests/EventStoreDBTests/ConnectionStringParserTests.swift
+++ b/Tests/EventStoreDBTests/ConnectionStringParserTests.swift
@@ -44,6 +44,16 @@ final class ConnectionStringParserTests: XCTestCase {
         XCTAssertEqual(endpoints?.count, 1)
         XCTAssertEqual(endpoints?[0].host, "localhost")
     }
+    
+    func test_host_should_be_parsed_host_contains_dash_succeed() throws {
+        let connectionString = "esdb://eventstore-service:2113?tls=false"
+
+        let parser = EndpointParser()
+        let endpoints = try parser.parse(connectionString)
+
+        XCTAssertEqual(endpoints?.count, 1)
+        XCTAssertEqual(endpoints?[0].host, "eventstore-service")
+    }
 
     func test_host_should_be_parsed_ip_succeed() throws {
         let connectionString = "esdb://192.168.41.32:2113?tls=false"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了主机名解析的正则表达式，允许更多字符出现在主机名末尾。
	- 增加了一个新的测试方法，以验证包含破折号的主机的连接字符串解析。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->